### PR TITLE
- fix shapes.svg "This XML file does not appear to have any style inf…

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -165,7 +165,9 @@ module.exports = function (grunt) {
                 prefix: 'svg-',
                 cleanup: true,
                 svg: {
-                    style: 'display:none'
+                    'xmlns': 'http://www.w3.org/2000/svg',
+                    'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+                    'style': 'display:none'
                 }
             }
         };


### PR DESCRIPTION
…ormation associated with it. The document tree is shown below." by adding '  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' attribute in svg tag.

This cause problem so svg can't load with <use xlink:href="#svg-some-id"></use>

https://infinit.io/_/3gpAU8G